### PR TITLE
Revert from version 1.0.0 to 0.2.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "speckjs",
   "main": "./lib/speckjs",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Comment Driven Development",
   "keywords": [
     "tdd",


### PR DESCRIPTION
`apm publish` requires the version bump to take place via CLI.
